### PR TITLE
記事一覧とマイページの画面に検索フォームを実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@ class ArticlesController < ApplicationController
   before_action :set_article, only: %i[ show edit update destroy ]
 
   def index
-    @articles = Article.all.page(params[:page])
+    @articles = Article.all.page(params[:page]).search(params[:title])
   end
 
   def show
@@ -54,6 +54,8 @@ class ArticlesController < ApplicationController
       format.json { head :no_content }
     end
   end
+
+
 
   private
     def set_article

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -6,7 +6,7 @@ class MypagesController < ApplicationController
   end
 
   def show
-    @articles = Article.where(user_id: current_user).page(params[:page])
+    @articles = Article.where(user_id: current_user).page(params[:page]).search(params[:title])
   end
 
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,15 @@
 class Article < ApplicationRecord
   validates :title, :content, presence: true
   belongs_to :user
+
+
+
+  def self.search(search)
+    if search
+      Article.where(["title LIKE?", "%#{search}%"])
+    else
+      Article.all
+    end
+  end
+
 end

--- a/app/views/articles/_search.html.erb
+++ b/app/views/articles/_search.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: articles_url, method: :get, local: true do |form| %>
+  <div class="row justify-content-center">
+    <div class="col-6">
+      <div class="mb-3">
+        <%= form.label 'タイトル', class: "form-label" %>
+        <%= form.text_field :title, value: params[:title], class: "form-control" %>
+      </div>
+      <div class="actions">
+        <%= form.submit '検索', class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1>記事</h1>
 
+<%= render partial: "search" %>
+
 <table class="table">
   <thead>
     <tr>

--- a/app/views/mypages/_search.html.erb
+++ b/app/views/mypages/_search.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: mypage_url, method: :get, local: true do |form| %>
+  <div class="row justify-content-center">
+    <div class="col-6">
+      <div class="mb-3">
+        <%= form.label 'タイトル', class: "form-label" %>
+        <%= form.text_field :title, value: params[:title], class: "form-control" %>
+      </div>
+      <div class="actions">
+        <%= form.submit '検索', class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,8 +1,9 @@
   <h1>マイページ</h1>
 
+<%= link_to '記事作成', new_article_path, class: "btn btn-info" %>
 
 
-
+<%= render partial: "search" %>
 
 <table class="table">
   <thead>
@@ -18,8 +19,8 @@
         <td><%= article.content %></td>
         <td>
           <%= link_to '詳細', article, class: "btn btn-success" %>
-        <td><%= link_to '編集', edit_article_path(article) %></td>
-        <td><%= link_to '削除', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '編集', edit_article_path(article), class: "btn btn-info" %></td>
+        <td><%= link_to '削除', article, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-info" %></td>
         </td>
       </tr>
     <% end %>
@@ -32,7 +33,6 @@
 
 
 
-<h1><%= link_to '記事作成', new_article_path %><h1>
 
 
 <%= paginate @articles, theme: 'twitter-bootstrap-4'%>


### PR DESCRIPTION
## 概要
今後、記事が増えていくことを考慮し、下記の条件で検索できるフォームを記事一覧とマイページの画面に実装
- タイトルで検索できる
- 部分一致で検索できる

記事一覧画面
<img width="780" alt="スクリーンショット 2022-05-20 0 21 37" src="https://user-images.githubusercontent.com/95083997/169334553-6f8c985c-a771-4628-ab37-0658ff4049f5.png">

マイページ画面
<img width="775" alt="スクリーンショット 2022-05-20 0 22 03" src="https://user-images.githubusercontent.com/95083997/169334637-92cc7f95-3237-4301-a03a-91bbe2a6160b.png">