### PR TITLE
記事とタグのアソシエーションの追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,4 +12,9 @@ class Article < ApplicationRecord
     end
   end
 
+
+  has_many :tag_articles
+  has_many :tags, through: :tag_articles
+
+
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,6 @@
 class Tag < ApplicationRecord
   validates :name, presence: true
+
+  has_many :tag_articles
+  has_many :articles, through: :tag_articles
 end


### PR DESCRIPTION
## 概要
記事とタグを紐付けるためにアソシエーションを設定

各記事とタグは多対多の関係となるため、
①まずは中間テーブルを作成し、
②その後、記事とタグのアソシエーションを組みました。
<img width="611" alt="スクリーンショット 2022-05-18 23 39 33" src="https://user-images.githubusercontent.com/95083997/169328325-00bd9e62-ceaa-4902-9ef4-06d92aad5336.png">
